### PR TITLE
fix: allow multiple js files in a function project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,15 @@ In a nutshell, when combined with the other buildpacks present in the [riff buil
 
 Detection passes if
 
-- a `$APPLICATION_ROOT/riff.toml` exists and
-- the build plan already contains a `npm` key (typically because an NPM based application was detected by the [npm buildpack](https://github.com/cloudfoundry/npm-cnb))
-  1. alternatively, if the file pointed to by the `artifact` value in `riff.toml` exists and has a `.js` extension
-
-If detection passes, the buildpack will add a `riff-invoker-node` key and `fn` metadata extracted from the riff metadata.
-
-If several languages are detected simultaneously, the detect phase errors out.
-The `override` key in `riff.toml` can be used to bypass detection and force the use of a particular invoker.
+- There is at least 1 .js file in the project that matches the `"main"` value in `package.json`
 
 ### Build Phase
 
 If a node function has been detected
 
 - Contributes the riff Node Invoker to a launch layer, set as the main `node` entry point with `FUNCTION_URI = <artifact>` set as an environment variable.
-  Note that `artifact` may actually be empty, in which case the invoker will `require()` the current directory (the function), which in turn expects that it contains a valid `package.json` file with its `main` entry point set.
+  Note that `artifact` is set via the invoker, when it does a `require()` in the current directory (the function), which in turn expects that it contains 
+  a valid `package.json` file with its `"main"` entry point set (see detection phase).
 
 The function behavior is exposed _via_ standard buildpack [process types](https://github.com/buildpack/spec/blob/master/buildpack.md#launch):
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # `node-function-buildpack`
 
+[![CircleCI](https://circleci.com/gh/heroku/node-function-buildpack.svg?style=svg)](https://circleci.com/gh/heroku/node-function-buildpack)
+
 The Node Function Buildpack is a Cloud Native Buildpack V3 that provides the riff [Node Function Invoker](https://github.com/projectriff/node-function-invoker) to functions.
 
 This buildpack is designed to work in collaboration with other buildpacks, which are tailored to

--- a/node/buildpack_test.go
+++ b/node/buildpack_test.go
@@ -25,7 +25,6 @@ import (
     "github.com/buildpack/libbuildpack/buildplan"
     "github.com/cloudfoundry/libcfbuildpack/test"
     nodeCNB "github.com/cloudfoundry/nodejs-cnb/node"
-    "github.com/cloudfoundry/npm-cnb/modules"
     "github.com/heroku/libfnbuildpack/function"
     . "github.com/onsi/gomega"
     "github.com/sclevine/spec"
@@ -68,32 +67,6 @@ func TestDetect(t *testing.T) {
             }
         })
 
-        it("passes if the NPM app BP applied", func() {
-            f.AddBuildPlan(modules.Dependency, buildplan.Dependency{})
-
-            plan, err := b.Detect(f.Detect, m)
-
-            g.Expect(err).To(BeNil())
-            g.Expect(plan).To(Equal(&buildplan.BuildPlan{
-                nodeCNB.Dependency: buildplan.Dependency{
-                    Metadata: buildplan.Metadata{"launch": true, "build": true},
-                },
-                Dependency: buildplan.Dependency{
-                    Metadata: buildplan.Metadata{FunctionArtifact: ""},
-                },
-            }))
-        })
-
-        it("should fail if more than one .js file exits", func() {
-            test.WriteFile(t, filepath.Join(f.Detect.Application.Root, "square.js"), "module.exports = x => x**2")
-            test.WriteFile(t, filepath.Join(f.Detect.Application.Root, "hello.js"), "module.exports = x => hello")
-
-            plan, err := b.Detect(f.Detect, m)
-
-            g.Expect(plan).To(BeNil())
-            g.Expect(err).ToNot(BeNil())
-        })
-
         it("should fail if no .js file exits", func() {
             plan, err := b.Detect(f.Detect, m)
 
@@ -119,7 +92,7 @@ func TestDetect(t *testing.T) {
             g.Expect(err).ToNot(BeNil())
         })
 
-        it("should enforce that package.json main field corresponds to a file", func() {
+        it("should enforce that package.json main field corresponds to an actual file", func() {
             packageDotJson := `{
 							    "name": "fixture",
 							    "version": "1.0.0",


### PR DESCRIPTION
The detection logic should allow there to be multiple `.js` files in the same function project directory. 

In order for detection to pass, there has to at least be 1 or more .js files and one of the files must correspond to the `main` value in the the `package.json` file.  If the `main` key is missing, detection will fail.