### PR TITLE
fix shellout to bin/detector and bin/builder to pass arguments

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -20,4 +20,4 @@ else
   echo "Version ${VERSION}"
 fi
 
-$BP_DIR/bin/builder $?
+$BP_DIR/bin/builder $@

--- a/bin/detect
+++ b/bin/detect
@@ -8,4 +8,4 @@ if [[ ! -f "$BP_DIR/bin/detect" ]] || [[ ! -f "$BP_DIR/bin/builder" ]]; then
   bash "$BP_DIR/bin/bootstrap" "$BP_DIR"
 fi
 
-$BP_DIR/bin/detector $?
+$BP_DIR/bin/detector $@


### PR DESCRIPTION
Fixes `incorrect number of command line arguments`, error during `detect` where the `os.Args` elements are incorrect.

```
os.Args = [/buildpacks/heroku_node-function/0.4.0/bin/detector 0]
```

Should be something along the lines of:
```
[/buildpacks/heroku_node-function/0.4.0/bin/detector /platform /tmp/0.4.0.plan.409369904/plan.toml]
```