### PR TITLE
Pass headers to middleware

### DIFF
--- a/system/index.js
+++ b/system/index.js
@@ -40,7 +40,7 @@ module.exports = async ({headers, payload}) => {
           if (DEBUG) {
             console.log(`MIDDLEWARE PAYLOAD: ${payload}`);
           }
-          payload = await middleware(payload);
+          payload = await middleware({payload, headers});
         } catch (err) {
           throw err
         }


### PR DESCRIPTION
This gives us more flexibility to do things like log the request-id, or handle special content-types like `application/cloudevents+json`.