### PR TITLE
fix Go version in bin/bootstrap

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -4,7 +4,7 @@
 set -eo pipefail
 
 BP_DIR="${1:?}"
-GO_VERSION="1.11.2"
+GO_VERSION="1.12.9"
 
 go_url() {
   local platform='unknown'


### PR DESCRIPTION
go.mod says 1.12, but bin/bootstrap downloads 1.11