### PR TITLE
Set api version to 0.2 in buildpack.toml

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+api = "0.2"
 
 [buildpack]
 id = "heroku/node-function"


### PR DESCRIPTION
I think this is all we need because we aren't using the build plan anymore