### PR TITLE
Remap headers to JS Object with k/v pairs

### DIFF
--- a/system/index.js
+++ b/system/index.js
@@ -26,7 +26,11 @@ function getFunction(uri) {
 const middlewareFns = getMiddlewareFunctions(MIDDLEWARE_FUNCTION_URI);
 const userFn = getFunction(USER_FUNCTION_URI);
 
-module.exports = async ({headers, payload}) => {
+module.exports = async (message) => {
+  const payload = message.payload;
+  // Remap headers to a standard JS object
+  const headers = message.headers.toRiffHeaders();
+  Object.keys(headers).map((key) => {headers[key] = message.headers.getValue(key)});
   if (DEBUG) {
     console.log('==System Function Start==');
     console.log(`HEADERS: ${JSON.stringify(headers)}`);


### PR DESCRIPTION
A Riff message's headers property is an instance of a custom class with special getters and setters (see https://github.com/projectriff/node-message/blob/master/lib/headers.js). It's hard to inspect or print, which makes it hard to write middleware against. This PR remaps the headers object to simple JS object key/value pairs, so it's easier to understand and write middleware against.