### PR TITLE
Support io.buildpacks.stacks.bionic stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -21,13 +21,16 @@ version = "0.5.0"
 [[stacks]]
 id = "heroku-18"
 
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"
+
 [[metadata.dependencies]]
 id      = "riff-invoker-node"
 name    = "riff Node Invoker"
 version = "0.1.3"
 uri     = "https://github.com/heroku/node-function-invoker/archive/v0.1.3-cloudevents.tar.gz"
 sha256  = "e1f2bd4e62588fcd80895e9df0db3c0beb6e4a2919f388802c307e529e58b47e"
-stacks  = [ "heroku-18" ]
+stacks  = [ "heroku-18", "io.buildpacks.stacks.bionic" ]
 
   [[metadata.dependencies.licenses]]
   type = "Apache-2.0"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,7 +16,7 @@ api = "0.2"
 [buildpack]
 id = "heroku/node-function"
 name = "Node Function Buildpack"
-version = "0.5.0"
+version = "0.5.1"
 
 [[stacks]]
 id = "heroku-18"


### PR DESCRIPTION
[This RFC](https://github.com/buildpacks/rfcs/pull/40) is working its way through and it seems useful to be able to use Heroku buildpacks on `cloudfoundry/cnb:bionic`. This also aligns with how riff is compatible with [multiple stacks](https://github.com/projectriff/node-function-buildpack/blob/master/buildpack.toml#L22).