### PR TITLE
Do not return undefined from user functions

### DIFF
--- a/system/index.js
+++ b/system/index.js
@@ -88,7 +88,9 @@ module.exports = async (message) => {
     throw error;
   }
 
-  return result;
+  if (typeof result !== 'undefined') {
+    return result
+  }
 };
 
 module.exports.$argumentType = 'message';


### PR DESCRIPTION
undefined return values will cause riff content negotiation to fail. We should not be returning anything in that case.

Thread here: https://heroku.slack.com/archives/CHYJ2J0QL/p1585844648035300